### PR TITLE
fix(bookstore): cannot find the pre-sale book ID

### DIFF
--- a/src/stores/booksCompany.ts
+++ b/src/stores/booksCompany.ts
@@ -109,7 +109,7 @@ function _getBooks($: CheerioAPI) {
       authors = authors.concat($(e).prop('title').split('、'));
     });
 
-    const id = $('input[name=prod_check]', elem).prop('value');
+    const id = ($(elem).attr('id') ?? '').match(/(?<=itemlist_)\S*/)?.[0] ?? '';
 
     const price = parseFloat(
       $('.list-nav', elem)


### PR DESCRIPTION
SInce some pre-sale books do not have the checkbox element we used to get book ID.