### PR TITLE
fix(bookstore): incorrect img source for booksCompany

### DIFF
--- a/src/stores/booksCompany.ts
+++ b/src/stores/booksCompany.ts
@@ -120,9 +120,15 @@ function _getBooks($: CheerioAPI) {
         .replace(/NT\$|,/g, ''),
     );
 
+    const rawThumbnailUrl = $('.box_1', elem)
+      .children('a')
+      .children('img')
+      .prop('data-src') as string;
+    const thumbnailUrl = _getBooksCompanyThumbnail(rawThumbnailUrl);
+
     books[i] = {
       id,
-      thumbnail: $('.box_1', elem).children('a').children('img').prop('data-src') as string,
+      thumbnail: thumbnailUrl,
       title: $('a[rel=mid_name]', elem).prop('title'),
       link: `https://www.books.com.tw/products/${id}`,
       priceCurrency: 'TWD',
@@ -140,4 +146,11 @@ function _getBooks($: CheerioAPI) {
   });
 
   return books;
+}
+
+function _getBooksCompanyThumbnail(url: string) {
+  const thumbnailRegexPattern = /.+\/getImage\?i=(https:\/\/.+\.jpg).+/;
+  const match = url.match(thumbnailRegexPattern);
+  const thumbnailUrl = match ? match[1] : 'null';
+  return thumbnailUrl;
 }

--- a/src/stores/booksCompany.ts
+++ b/src/stores/booksCompany.ts
@@ -122,7 +122,7 @@ function _getBooks($: CheerioAPI) {
 
     books[i] = {
       id,
-      thumbnail: $('a[rel=mid_image]', elem).children('img').data('src') as string,
+      thumbnail: $('.box_1', elem).children('a').children('img').prop('data-src') as string,
       title: $('a[rel=mid_name]', elem).prop('title'),
       link: `https://www.books.com.tw/products/${id}`,
       priceCurrency: 'TWD',

--- a/src/stores/booksCompany.ts
+++ b/src/stores/booksCompany.ts
@@ -120,10 +120,10 @@ function _getBooks($: CheerioAPI) {
         .replace(/NT\$|,/g, ''),
     );
 
-    const rawThumbnailUrl = $('.box_1', elem)
+    const rawThumbnailUrl: string = $('.box_1', elem)
       .children('a')
       .children('img')
-      .prop('data-src') as string;
+      .prop('data-src');
     const thumbnailUrl = _getBooksCompanyThumbnail(rawThumbnailUrl);
 
     books[i] = {


### PR DESCRIPTION
#### Update:
  0103: Use regex to get the proper image from data-src.

#### Change:
  - Update the quering field of the book image from BookCompany.
  - Due to fields change, we can't get the correct image.
  - We'll get the url of this **i** value: getImage?i=https://www.books.com.tw/img/E05/001/27/E050012722.jpg

source sample:
```html
<div class="box_1">
	<i class="sign_ebook"></i>
	<a target="_blank"
		href="//search.books.com.tw/redirect/move/key/%E9%AB%98%E6%95%88%E4%BA%BA%E7%94%9F%E7%9A%84%E6%B8%85%E5%96%AE%E6%95%B4%E7%90%86%E8%A1%93/area/mid/item/E050012722/page/1/idx/5/cat/E05/pdf/1/spell/1"
		title="Evernote 100個做筆記的好方法：數位化重整你的工作與人生(全新增訂版) (電子書)"><img class="b-lazy"
			src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
			data-src="https://im1.book.com.tw/image/getImage?i=https://www.books.com.tw/img/E05/001/27/E050012722.jpg&amp;w=187&amp;h=187&amp;v=59a54b4c"
			data-srcset="https://im1.book.com.tw/image/getImage?i=https://www.books.com.tw/img/E05/001/27/E050012722.jpg&amp;w=374&amp;h=374&amp;v=59a54b4c 2x"
			alt="Evernote 100個做筆記的好方法：數位化重整你的工作與人生(全新增訂版) (電子書)"></a>
```
     - Change the target fields to: .box_1 class -> a -> img -> data-src field.


#### Preview:

| before | after |
| ---- | ---- |
|<img width="800px" src="https://user-images.githubusercontent.com/4803452/210191210-15f0905d-2794-4896-a13c-89b1a4cd1384.png" />|<img width="800px" src="https://user-images.githubusercontent.com/4803452/210289558-8cf47a32-aaaa-4e6d-9d27-837d10e440c8.png" />|






