### PR TITLE
fix(bookstore): google play no data issue

### DIFF
--- a/src/stores/playStore.ts
+++ b/src/stores/playStore.ts
@@ -112,7 +112,7 @@ function _getBooks($: cheerio.CheerioAPI, rootURL: string, base: string) {
 
     // 透過語意化連結取得書籍頁面 URL
     const $link = $bookElem.find('a[href*="/store/books/details"]');
-    const href = $link.attr('href') ?? $bookElem.find('a').attr('href') ?? '';
+    const href = $link.attr('href') ?? '';
 
     if (!href) return;
 

--- a/src/stores/playStore.ts
+++ b/src/stores/playStore.ts
@@ -97,84 +97,82 @@ export default (
 
 // parse 找書
 function _getBooks($: cheerio.CheerioAPI, rootURL: string, base: string) {
-  const $list = $('body > c-wiz')
-    .eq(1)
-    .children('div')
-    .children('div')
-    .children('c-wiz')
-    .children('c-wiz')
-    .find('div[role=listitem]');
+  const $list = $('div[role=listitem]');
 
-  let books: Book[] = [];
+  const books: Book[] = [];
 
   // 找不到就是沒這書
   if (!$list.length) {
     console.log('Not found in Play Store!');
-
     return books;
   }
 
-  $list.each((i, elem) => {
+  $list.each((_i, elem) => {
     const $bookElem = $(elem);
 
-    let linkUrl = new URL(
-      $bookElem.children('div').eq(0).children('div').eq(0).children('a').prop('href') ?? '',
-      base,
-    );
+    // 透過語意化連結取得書籍頁面 URL
+    const $link = $bookElem.find('a[href*="/store/books/details"]');
+    const href = $link.attr('href') ?? $bookElem.find('a').attr('href') ?? '';
 
-    const id = linkUrl.searchParams.get('id') as string;
+    if (!href) return;
 
-    let price = Number(0);
-    const $priceRootElem = $bookElem
-      .children('div')
-      .eq(0)
-      .children('div')
-      .eq(0)
-      .children('a')
-      .children('div')
-      .eq(1)
-      .children('div')
-      .eq(1)
-      .children('div')
-      .last()
-      .children()
-      .children('span');
-    if ($priceRootElem.text() != '免費') {
-      const priceElems = $priceRootElem.find('span[aria-hidden="true"] > span');
-      if (!priceElems.length) {
-        price = Number($priceRootElem.text().replace(/\$|,/g, ''));
+    const linkUrl = new URL(href, base);
+    const id = linkUrl.searchParams.get('id');
+
+    if (!id) return;
+
+    // 取得書名：優先使用 div[title]，備用 img alt 屬性
+    let title = $bookElem.find('div[title]').attr('title') ?? '';
+    if (!title) {
+      const alt = $bookElem.find('img').attr('alt') ?? '';
+      title = alt.replace(/^「|」圖示圖片$/g, '');
+    }
+
+    // 解析價格：透過 aria-label 中的金額資訊
+    let price: number = -1;
+    const $priceSpan = $bookElem.find('span[aria-label*="$"]');
+
+    if ($priceSpan.length > 0) {
+      const ariaLabel = $priceSpan.attr('aria-label') ?? '';
+      const priceMatches = ariaLabel.match(/\$[\d,.]+/g);
+
+      if (priceMatches) {
+        price = priceMatches
+          .map((match) => parseFloat(match.replace(/[^\d.]/g, '')))
+          .sort((a, b) => a - b)[0];
       } else {
-        price = priceElems
-          .map((index, priceElem) => Number($(priceElem).text().replace(/\$|,/g, '')))
-          .get()
-          .sort((a: number, b: number) => a - b)[0];
+        const cleaned = $priceSpan
+          .text()
+          .replace(/[^\d.]/g, '')
+          .trim();
+        price = parseFloat(cleaned) || -1;
       }
+    } else {
+      // 備用方案：遍歷 span 尋找含有 $ 符號的文字
+      $bookElem.find('span').each((_j, span) => {
+        const text = $(span).text();
+        const priceMatch = text.match(/\$[\d,.]+/);
+        if (priceMatch) {
+          price = parseFloat(priceMatch[0].replace(/[^\d.]/g, ''));
+          return false; // 中斷 each 迴圈
+        }
+      });
     }
 
     // 設定書籍網址的語言與國家
     linkUrl.searchParams.set('gl', 'tw');
     linkUrl.searchParams.set('hl', 'zh-tw');
 
-    let book: Book = {
+    const book: Book = {
       id,
       thumbnail: `${rootURL}/books/publisher/content/images/frontcover/${id}?fife=w256-h256`,
-      title: $bookElem
-        .children('div')
-        .eq(0)
-        .children('div')
-        .eq(0)
-        .children('a')
-        .children('div')
-        .eq(1)
-        .children('div')
-        .eq(0)
-        .prop('title'),
+      title,
       link: linkUrl.href,
       priceCurrency: 'TWD',
       price,
     };
 
-    books[i] = book;
+    books.push(book);
   });
 
   return books;

--- a/src/stores/playStore.ts
+++ b/src/stores/playStore.ts
@@ -134,10 +134,12 @@ function _getBooks($: cheerio.CheerioAPI, rootURL: string, base: string) {
 
     if ($priceSpan.length > 0) {
       const ariaLabel = $priceSpan.attr('aria-label') ?? '';
+      // 同時支援 $399 與 $1,299，逗號可有可無
       const priceMatches = ariaLabel.match(/\$[\d,.]+/g);
 
       if (priceMatches) {
         price = priceMatches
+          // 僅做字串清洗與轉數字，不是第二次千分號判斷
           .map((match) => parseFloat(match.replace(/[^\d.]/g, '')))
           .sort((a, b) => a - b)[0];
       } else {
@@ -148,7 +150,7 @@ function _getBooks($: cheerio.CheerioAPI, rootURL: string, base: string) {
         price = parseFloat(cleaned) || -1;
       }
     } else {
-      // 備用方案：遍歷 span 尋找含有 $ 符號的文字
+      // 備用方案：aria-label 抓不到價格時，才遍歷 span 文字
       $bookElem.find('span').each((_j, span) => {
         const text = $(span).text();
         const priceMatch = text.match(/\$[\d,.]+/);


### PR DESCRIPTION
### Changes
  - Fix google play some fields is null issue.

### Previews

<img width="1481" height="874" alt="image" src="https://github.com/user-attachments/assets/74aa6192-e570-4f15-9215-01f06c439e47" />

### Q&A

#### 🤖 Analyzed by Claude Opus 4.6 thinking

**核心問題：** Google Play 每次 build 都可能改變 class name 和 DOM 層級結構，為什麼這次的修復不會再次失效？

**關鍵差異：** 這次的選取器完全不依賴 class name 或 DOM 深度，而是使用 HTML 語意化屬性：

| 選取器 | 穩定性依據 |
|--------|----------|
| `div[role=listitem]` | WAI-ARIA 標準屬性，用於無障礙功能支援。改動會影響螢幕閱讀器，Google 通常不會移除 |
| `a[href*="/store/books/details"]` | URL path 結構屬於路由層級設計，改動頻率遠低於前端佈局 |
| `div[title]` | HTML 原生屬性，提供 hover tooltip，也屬於無障礙功能的一部分 |
| `span[aria-label*="$"]` | ARIA 標準屬性，用來描述價格給螢幕閱讀器，受 accessibility 法規保護 |

**舊寫法為什麼脆弱：** `eq(1).children('div').children('div')` 依賴「第幾層的第幾個 div」，Google 每次 build 多包一層 wrapper div 或換掉順序，整條 chain 就斷了。

**新寫法為什麼穩定：** `.find()` 會在整個子樹中搜尋，不在乎目標元素被包了幾層 div。

### 仍可能導致爬蟲失效的情境

以下情境仍可能需要重新調整爬蟲：

1. **改用 SPA client-side rendering** — 需要換成 headless browser（如 Puppeteer）
2. **URL 結構重新設計** — `/store/books/details` 路徑消失
3. **移除 ARIA 屬性** — 可能性低，違反 accessibility 法規
4. **Book ID 供應方式改變** — 不再透過 URL query parameter 傳遞




